### PR TITLE
CI: adopt central d-morrison/gha reusable workflows (links + summary)

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -13,6 +13,10 @@ on:
 
 jobs:
   check:
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     uses: d-morrison/gha/.github/workflows/check-links.yml@v1
     with:
       lychee-config: lychee.toml

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -5,26 +5,14 @@ on:
     branches:
       - main
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   schedule:
     # Run weekly on Mondays at 9:00 UTC to catch link rot
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
 jobs:
-  link-checker:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-
-      - name: Check links in markdown and HTML files
-        uses: lycheeverse/lychee-action@v2
-        with:
-          # Check all .qmd (Quarto markdown), .md (markdown), and .html files
-          args: --verbose --no-progress --config lychee.toml './**/*.qmd' './**/*.md' './**/*.html'
-          # Fail action on broken links
-          fail: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check:
+    uses: d-morrison/gha/.github/workflows/check-links.yml@v1
+    with:
+      lychee-config: lychee.toml

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -6,29 +6,4 @@ on:
 
 jobs:
   summary:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      models: read
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run AI inference
-        id: inference
-        uses: actions/ai-inference@v1
-        with:
-          prompt: |
-            Summarize the following GitHub issue in one paragraph:
-            Title: ${{ github.event.issue.title }}
-            Body: ${{ github.event.issue.body }}
-
-      - name: Comment with AI summary
-        run: |
-          gh issue comment $ISSUE_NUMBER --body '${{ steps.inference.outputs.response }}'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
-          RESPONSE: ${{ steps.inference.outputs.response }}
+    uses: d-morrison/gha/.github/workflows/summary.yml@v1

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -6,4 +6,8 @@ on:
 
 jobs:
   summary:
+    permissions:
+      issues: write
+      models: read
+      contents: read
     uses: d-morrison/gha/.github/workflows/summary.yml@v1


### PR DESCRIPTION
Pilot migration to the new central reusable-workflows repo **[d-morrison/gha](https://github.com/d-morrison/gha)** (`@v1`).

## What changed
- `check-links.yml` and `summary.yml` are now ~6-line caller stubs that invoke `d-morrison/gha/.github/workflows/{check-links,summary}.yml@v1`.
- `check-links` keeps using this repo's `lychee.toml` (passed as `lychee-config`) and additionally gains the central workflow's skip-label override and auto-issue-on-main.
- The deliberately-disabled `check-bibliography-dois.yml` (OUP/ACS 403 blocking) is **left untouched**.

## Why
Consolidating duplicated GitHub Actions into a single source of truth (modeled on r-lib/actions, easystats/workflows). See the central repo's README.

## Verification
This PR's `pull_request` event triggers `check-links` via the reusable workflow — confirming the cross-repo `@v1` call works. `summary` runs only on newly opened issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)