### PR TITLE
Incorporate ai-config skills via plugin marketplace

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "extraKnownMarketplaces": {
+    "d-morrison": {
+      "source": { "source": "github", "repo": "d-morrison/ai-config" }
+    }
+  },
+  "enabledPlugins": {
+    "ai-config@d-morrison": true
+  }
+}


### PR DESCRIPTION
## Summary

Makes the shared **`d-morrison/ai-config`** workflow skills available inside this repo by enabling ai-config's plugin marketplace, rather than copying any skill files in.

Adds a single file, `.claude/settings.json`:

```json
{
  "extraKnownMarketplaces": {
    "d-morrison": {
      "source": { "source": "github", "repo": "d-morrison/ai-config" }
    }
  },
  "enabledPlugins": {
    "ai-config@d-morrison": true
  }
}
```

This is exactly the consumer-repo mechanism documented in [ai-config's `README.md`](https://github.com/d-morrison/ai-config#use-these-skills-in-another-repos-web-sessions-plugin-marketplace) — skills stay single-sourced in `d-morrison/ai-config` and are pulled in here by reference (no duplication; new skills are picked up automatically).

## What this enables

Once merged, the ai-config skills (`ardi`, `gii`, `iterate`, `reprexes`, `r-pkg-spellcheck`, `memorize`, etc.) become available, namespaced as `/ai-config:<skill>`, on both psw surfaces:

- **Claude Code on the web** — sessions opened on psw install the plugin at session start (the documented purpose of this file).
- **The `@claude` CI bot** — `claude-code-action` runs the CLI against the checked-out repo and reads this project settings file; `restoreConfigFromBase` restores `.claude/` from the base branch, so the config takes effect for PR-triggered runs once it lands on `main`.

## Scope / non-overlap

- Touches only the new `.claude/settings.json`. It does **not** modify any workflow YAML, so it does not collide with #31 (which migrates `claude.yml` / `claude-code-review.yml` to the central gha reusable workflows).
- No skills are vendored into the repo — ai-config remains the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018v7h9ZVVQRBjdyRFGXCrzG)_