### PR TITLE
Add "Avoiding AI tells" chapter

### DIFF
--- a/_quarto-website.yml
+++ b/_quarto-website.yml
@@ -41,6 +41,8 @@ website:
             href: chapters/paper-organization.qmd
           - text: "Word choice"
             href: chapters/word-choice.qmd
+          - text: "Avoiding AI tells"
+            href: chapters/avoid-ai-tells.qmd
           - text: "Grammar"
             href: chapters/grammar.qmd
           - text: "Conciseness"

--- a/chapters/avoid-ai-tells.qmd
+++ b/chapters/avoid-ai-tells.qmd
@@ -1,0 +1,139 @@
+---
+title: "Avoiding AI tells"
+format:
+  html: default
+  revealjs:
+    output-file: avoid-ai-tells-slides.html
+  pdf:
+    output-file: avoid-ai-tells-handout.pdf
+  docx:
+    output-file: avoid-ai-tells.docx
+---
+
+{{< include _copilot-disclaimer.qmd >}}
+
+AI writing assistants have a recognizable house style.
+When you let one draft your prose,
+it leaves fingerprints:
+words, sentence shapes, and formatting habits
+that recur across unrelated documents.
+Readers who have seen enough machine-generated text learn to spot these patterns,
+and once they do,
+the writing reads as generic and unconsidered,
+even when the underlying content is sound.
+
+This chapter catalogs the most common tells so you can remove them.
+It is written mainly for AI assistants drafting scientific prose,
+but it is just as useful for humans editing AI-assisted drafts.
+
+One caveat first:
+no single word or pattern below is wrong on its own.
+Each has legitimate uses.
+The signal is clustering and mechanical repetition,
+the same constructions appearing again and again
+regardless of what the sentence needs.
+Edit for the cluster, not the isolated instance,
+and do not flatten your prose into a voiceless register
+trying to avoid every word on a list.
+
+## Overused vocabulary
+
+Some words appear far more often in machine-generated text
+than in careful human writing.
+Many are also Latin-derived words with plainer alternatives,
+so the advice here overlaps with the [Word choice](word-choice.qmd) chapter.
+@tbl-ai-vocabulary lists frequent offenders and plainer replacements.
+
+:::{#tbl-ai-vocabulary}
+
+Overused | Plainer alternative
+-------- | -------------------
+delve into | examine, study
+leverage | use
+utilize | use
+showcase | show
+robust | reliable, well-tested
+seamless | smooth
+pivotal, crucial | important, key
+testament to | shows, demonstrates
+
+Words overused by AI assistants and plainer alternatives
+
+:::
+
+Whole phrases recur too.
+"In today's fast-paced world",
+"it is important to note that",
+and "plays a vital role in"
+add length without content;
+delete them and start with the actual point.
+
+## Rhetorical reflexes
+
+AI assistants reach for a few sentence shapes by reflex,
+whether or not the content calls for them.
+
+The strongest tell is the *not just X, but Y* antithesis.
+It promises a profound contrast and usually delivers a hollow one.
+
+:::{#exm-antithesis}
+
+## The "not just X, but Y" reflex
+
+> ❌ This method is not just fast — it is transformative.
+>
+> ✅ This method runs in half the time of the previous approach.
+
+The plain version makes a concrete, verifiable claim.
+The antithesis frame makes none.
+
+:::
+
+Other reflexes to watch for:
+
+- **Mechanical lists of three.** Three parallel items appear whether or not
+  three is the right count. Use the number of items the point actually needs.
+- **Signpost filler.** Phrases like "it is worth noting that" and "importantly"
+  announce a point instead of making it. Cut them and state the point directly.
+- **Hedging stacks.** "May potentially suggest" and "could possibly indicate"
+  pile up qualifiers. Keep one honest hedge; drop the rest.
+- **Hollow summaries.** A closing paragraph that opens with "in conclusion" and
+  only restates what you just said adds nothing. End on a real point.
+
+## Formatting habits
+
+Some tells are typographic rather than verbal.
+
+- **The em-dash as a default connector.** AI text reaches for the em-dash to
+  join almost any two clauses. Vary your punctuation: a period, a comma, or a
+  semicolon is often the better fit.
+- **Bold-leading bullets everywhere.** A `**Term:** explanation` bullet is fine
+  once, but applying the pattern to every list turns it into a tic. Use it when
+  the label earns emphasis, plain bullets otherwise.
+- **Emoji section headers.** Emoji in headings signal a blog post, not a
+  scientific document. Leave them out.
+- **Uniform paragraph rhythm.** Paragraphs of near-identical length, each three
+  or four sentences, read as machine-paced. Let paragraph length follow the
+  ideas.
+
+## Tone
+
+The last group of tells is about register.
+
+- **Promotional language.** Words like "powerful", "game-changing", and
+  "cutting-edge" sell rather than inform. Describe what the thing does and let
+  the reader judge.
+- **Reflexive both-sides framing.** Tacking "however, it is important to
+  consider the other side" onto every claim signals caution without adding
+  content. Hedge when the evidence is genuinely mixed, not by habit.
+- **Vague universals.** "Studies show" and "experts agree", with no specific
+  source or number, are tells precisely because they dodge the evidence. Name
+  the study and give the number, as the [Citations and evidence](citations-evidence.qmd)
+  chapter recommends.
+
+A short scan for these patterns before you submit a draft
+catches most of them.
+Cut the filler and the reflexes,
+but keep your own voice:
+the goal is clear, honest prose,
+not prose that has been sanded smooth.


### PR DESCRIPTION
Closes #37.

## What

Adds a new chapter, `chapters/avoid-ai-tells.qmd`, cataloging the patterns that mark prose as AI-generated so writers can remove them. The chapter is aimed mainly at AI writing assistants drafting scientific prose, and at humans editing AI-assisted drafts (per the issue).

It groups the tells into four sections:

- **Overused vocabulary** — a table of frequent offenders (`delve into`, `leverage`, `robust`, `pivotal`, `testament to`, …) with plainer alternatives, cross-referencing the existing **Word choice** chapter.
- **Rhetorical reflexes** — the *not just X, but Y* antithesis (with a ❌/✅ example), mechanical lists of three, signpost filler, hedging stacks, and hollow summaries.
- **Formatting habits** — em-dash overuse, mechanically applied bold-leading bullets, emoji headers, uniform paragraph rhythm.
- **Tone** — promotional language, reflexive both-sides framing, and vague universals (cross-referencing **Citations and evidence**).

## Why

Issue #37 asks for a section on avoiding AI "tells". As the lab increasingly drafts with AI assistance, a shared catalog of these patterns gives both the assistants and their human editors a checklist to work against.

## Notes

- Linked in the navbar in `_quarto-website.yml`, positioned after **Word choice** (closest thematic fit).
- Follows the existing chapter conventions: the four-format `format:` front matter, the `_copilot-disclaimer.qmd` include, `:::{#tbl-…}` / `:::{#exm-…}` callouts, and ❌/✅ example pairs as in **Word choice** and **Conciseness**.
- The chapter tries to practice what it preaches: moderate em-dash use, no antithesis reflex in its own prose, and bold-leading bullets only for the genuinely term-defining lists (the legitimate use the chapter describes).
- Verified locally: renders to HTML cleanly, the navbar entry appears, `@tbl-ai-vocabulary` resolves to "Table 1", and the cross-chapter links resolve to the right `.html` pages. No `_site/`/`_freeze/` artifacts committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SMifRtfsNmVvNrh5jMFz13

---
_Generated by [Claude Code](https://claude.ai/code/session_01SMifRtfsNmVvNrh5jMFz13)_