### PR TITLE
Repoint gha reusable workflows to Morrison-Lab/gha

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -17,6 +17,6 @@ jobs:
       contents: read
       issues: write
       pull-requests: read
-    uses: d-morrison/gha/.github/workflows/check-links.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/check-links.yml@v1
     with:
       lychee-config: lychee.toml

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,4 +1,4 @@
-# Thin caller for the central d-morrison/gha reusable Claude code-review
+# Thin caller for the central Morrison-Lab/gha reusable Claude code-review
 # workflow. Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret (passed via
 # `secrets: inherit`). The workflow_dispatch path lets claude.yml re-dispatch a
 # review after an @claude run pushes commits — keep this file named
@@ -22,7 +22,7 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
-    uses: d-morrison/gha/.github/workflows/claude-code-review.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/claude-code-review.yml@v1
     secrets: inherit
     with:
       # Wires the workflow_dispatch input through so claude.yml can re-dispatch

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,4 +1,4 @@
-# Thin caller for the central d-morrison/gha reusable Claude Code workflow.
+# Thin caller for the central Morrison-Lab/gha reusable Claude Code workflow.
 # Requires the CLAUDE_CODE_OAUTH_TOKEN repository secret. The calling job grants
 # write permissions so Claude (agent mode) can push branches and open PRs;
 # `secrets: inherit` passes CLAUDE_CODE_OAUTH_TOKEN through to the reusable
@@ -37,7 +37,7 @@ jobs:
       issues: write
       id-token: write
       actions: write       # dispatch the review workflow via `gh workflow run`
-    uses: d-morrison/gha/.github/workflows/claude.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/claude.yml@v1
     secrets: inherit
     with:
       setup-r: false          # psw is a Quarto book with no R package code

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -10,4 +10,4 @@ jobs:
       issues: write
       models: read
       contents: read
-    uses: d-morrison/gha/.github/workflows/summary.yml@v1
+    uses: Morrison-Lab/gha/.github/workflows/summary.yml@v1


### PR DESCRIPTION
The `gha` repo moved from `d-morrison/gha` to `Morrison-Lab/gha`.

GitHub Actions does **not** follow repository-rename redirects for `uses:`, so
every call in this repo was failing to resolve before any job started. This
repoints all 6 reference(s) across 4 workflow file(s). Tags and paths
are unchanged.

Direct push to the default branch was blocked by repository rules, so this is a PR.