### PR TITLE
Add guidance against flippant appeals to obviousness

### DIFF
--- a/chapters/citations-evidence.qmd
+++ b/chapters/citations-evidence.qmd
@@ -72,6 +72,110 @@ However,
 when in doubt,
 provide a citation—over-citing is preferable to under-citing.
 
+## Do not substitute flippancy for support
+
+Some phrases assert that a claim needs no support
+instead of supplying any:
+
+- "it is obvious that"
+- "clearly, it follows that"
+- "it should be familiar to you that"
+- "the familiar formula"
+- "of course"
+- "as everyone knows"
+
+The problem is the appeal, not the individual words:
+"clearly" is fine as an adverb of manner
+("the methods section clearly describes the sampling frame"),
+and becomes a problem only when it stands in for an argument.
+
+These phrases do no work for the reader.
+A reader who already knows the result gains nothing
+from being told that it is familiar,
+and a reader who does not
+is told that the gap is their own fault,
+without being given any way to close it.
+The phrasing also conceals a common failure mode:
+writers reach for "obviously" most often
+at the steps they have checked least carefully.
+If you cannot supply a derivation or a citation for a step,
+that is a reason to work the step out,
+not a reason to call it obvious.
+
+Replace such phrases with one of the following:
+
+- **A direct derivation.**
+  Show the intermediate steps,
+  or state which identity or algebraic manipulation takes you from one line to the next.
+- **A specific citation.**
+  Name the source that establishes the result,
+  and give a chapter, section, page, or equation number
+  whenever the source is long enough
+  that a bare citation would leave the reader searching.
+- **A cross-reference.**
+  When you established the result earlier in the same document,
+  point to it by number
+  (see [Defining terms clearly](defining-terms.qmd)
+  for the Quarto cross-reference syntax).
+
+Deleting the phrase and keeping the claim
+is also usually an improvement:
+"the log-likelihood is a sum of three terms"
+asserts exactly as much as
+"the log-likelihood is obviously a sum of three terms",
+and it invites the reader to check the claim
+rather than to defer to it.
+
+:::{#exm-flippant-derivation}
+
+## Replacing an appeal to familiarity
+
+> ❌ Substituting the normal density into the likelihood
+> gives the familiar three-term formula.
+>
+> ✅ For an independent sample $x_1, \ldots, x_n$
+> from a normal distribution with mean $\mu$ and variance $\sigma^2$,
+> substituting the normal density into the likelihood
+> and taking logarithms gives
+> $$
+> \ell(\mu, \sigma^2) =
+> -\frac{n}{2}\log(2\pi)
+> - \frac{n}{2}\log\left(\sigma^2\right)
+> - \frac{1}{2\sigma^2}\sum_{i=1}^{n}\left(x_i - \mu\right)^2.
+> $$
+> The three terms are,
+> in order:
+> a constant that does not involve the parameters,
+> a term that depends on $\sigma^2$ but not on $\mu$,
+> and the sum of squared deviations of the data from $\mu$,
+> divided by $-2\sigma^2$.
+
+The second version gives the reader the formula and where it came from,
+so they can check the algebra themselves.
+The first version asks them to take the writer's word for it,
+and offers no help to anyone who has not seen the result before.
+
+:::
+
+### "Trivial" and "trivially"
+
+"Trivial" and "trivially" usually work the same way:
+they announce that a step is too small to write down,
+which relieves the writer of writing it down.
+Treat them as a prompt to check the step,
+and to write it out if it takes only a line.
+
+The word has one defensible use,
+which is describing how a general expression reduces to a simpler one
+in a special case —
+for example,
+how a weighted average reduces to an ordinary average
+when all of the weights are equal.
+Even in that use,
+"minimal case" or "degenerate case"
+names the situation more precisely,
+and avoids the dismissive tone that "trivial" carries.
+
 ## What makes a citation relevant
 
 A relevant citation is one that actually supports the specific claim you are making.
@@ -186,7 +290,8 @@ To effectively support your claims:
 ## Common citation errors to avoid
 
 - **Citation needed**: Making claims without any supporting citation or evidence
-- **Vague attribution**: Using phrases like "studies have shown" without citing specific studies  
+- **Vague attribution**: Using phrases like "studies have shown" without citing specific studies
+- **Appeal to obviousness**: Using "obviously", "clearly", or "as is well known" in place of a derivation or a citation
 - **Circular citation**: Citing a paper that doesn't contain the claimed information but cites another paper that does (cite the original source)
 - **Citation padding**: Adding citations that don't actually support your claims just to appear well-referenced
 - **Selective citation**: Only citing work that supports your position while ignoring contradictory evidence
@@ -234,5 +339,5 @@ understand the foundation of your arguments,
 and locate resources for further learning.
 Always ask yourself:
 "How does my reader know this is true?"
-If the answer isn't obvious from your text,
+If your text does not answer that question,
 add a citation or present direct evidence.

--- a/chapters/citations-evidence.qmd
+++ b/chapters/citations-evidence.qmd
@@ -95,12 +95,13 @@ from being told that it is familiar,
 and a reader who does not
 is told that the gap is their own fault,
 without being given any way to close it.
-The phrasing also conceals a common failure mode:
-writers reach for "obviously" most often
-at the steps they have checked least carefully.
-If you cannot supply a derivation or a citation for a step,
-that is a reason to work the step out,
-not a reason to call it obvious.
+They also cost the writer something.
+Working a step out is how you find out whether it holds;
+calling it obvious settles the question by assertion,
+and leaves any error in the step where it is.
+So if you cannot supply a derivation or a citation for a step,
+treat that as a reason to work the step out,
+not as a reason to call it obvious.
 
 Replace such phrases with one of the following:
 
@@ -121,7 +122,7 @@ Replace such phrases with one of the following:
 Deleting the phrase and keeping the claim
 is also usually an improvement:
 "the log-likelihood is a sum of three terms"
-asserts exactly as much as
+makes the same claim about the log-likelihood as
 "the log-likelihood is obviously a sum of three terms",
 and it invites the reader to check the claim
 rather than to defer to it.

--- a/chapters/citations-evidence.qmd
+++ b/chapters/citations-evidence.qmd
@@ -84,10 +84,13 @@ instead of supplying any:
 - "of course"
 - "as everyone knows"
 
-The problem is the appeal, not the individual words:
-"clearly" is fine as an adverb of manner
+The problem is the appeal, not the individual words.
+"Clearly" is fine as an adverb of manner
 ("the methods section clearly describes the sampling frame"),
-and becomes a problem only when it stands in for an argument.
+and "of course" is fine when it flags an assumption
+you have already established.
+Each becomes a problem only when it stands in
+for an argument you have not made.
 
 These phrases do no work for the reader.
 A reader who already knows the result gains nothing
@@ -168,9 +171,9 @@ and to write it out if it takes only a line.
 
 The word has one defensible use,
 which is describing how a general expression reduces to a simpler one
-in a special case —
-for example,
-how a weighted average reduces to an ordinary average
+in a special case.
+For example,
+a weighted average reduces to an ordinary average
 when all of the weights are equal.
 Even in that use,
 "minimal case" or "degenerate case"
@@ -292,7 +295,7 @@ To effectively support your claims:
 
 - **Citation needed**: Making claims without any supporting citation or evidence
 - **Vague attribution**: Using phrases like "studies have shown" without citing specific studies
-- **Appeal to obviousness**: Using "obviously", "clearly", or "as is well known" in place of a derivation or a citation
+- **Appeal to obviousness**: Using "obviously", "clearly", or "as everyone knows" in place of a derivation or a citation
 - **Circular citation**: Citing a paper that doesn't contain the claimed information but cites another paper that does (cite the original source)
 - **Citation padding**: Adding citations that don't actually support your claims just to appear well-referenced
 - **Selective citation**: Only citing work that supports your position while ignoring contradictory evidence

--- a/chapters/citations-evidence.qmd
+++ b/chapters/citations-evidence.qmd
@@ -149,10 +149,11 @@ rather than to defer to it.
 > $$
 > The three terms are,
 > in order:
-> a constant that does not involve the parameters,
-> a term that depends on $\sigma^2$ but not on $\mu$,
-> and the sum of squared deviations of the data from $\mu$,
-> divided by $-2\sigma^2$.
+>
+> - a constant that does not involve the parameters;
+> - a term that depends on $\sigma^2$ but not on $\mu$;
+> - the sum of squared deviations of the data from $\mu$,
+>   divided by $-2\sigma^2$.
 
 The second version gives the reader the formula and where it came from,
 so they can check the algebra themselves.


### PR DESCRIPTION
## Why

Phrases like "it is obvious that", "clearly, it follows that", and "the familiar formula" assert that a claim needs no support instead of supplying any. A reader who already knows the result gains nothing from being told it is familiar; a reader who does not is told the gap is their own fault and given no way to close it.

The guide had no section on this, and its "common citation errors" list covered vague attribution ("studies have shown") but not the appeal-to-obviousness version of the same dodge.

## What changed

All changes are in `chapters/citations-evidence.qmd`, which is the natural home since the remedy is to prove the result or cite a specific source.

- New section **"Do not substitute flippancy for support"**, placed after "What constitutes adequate support":
  - names the offending phrases, with a caveat that the problem is the appeal rather than the individual words — "clearly" is fine as an adverb of manner, and "of course" is fine when it flags an assumption you have already established;
  - gives three replacements — a direct derivation, a specific citation with a chapter/section/page/equation locator, or a cross-reference to an earlier result in the same document;
  - notes that deleting the phrase makes the same claim as keeping it, while inviting the reader to check that claim rather than defer to it;
  - works an example through the rewrite: "the familiar three-term formula" becomes the normal log-likelihood written out, with its three terms listed against the equation.
- New subsection on **"trivial" / "trivially"**. Its one defensible use — describing how a general expression reduces in a special case — is usually served better by "minimal case" or "degenerate case", which name the situation more precisely and avoid the dismissive tone.
- Added an **"Appeal to obviousness"** bullet to the chapter's list of common citation errors.
- Reworded the chapter conclusion so it does not lean on "obvious" itself ("If your text does not answer that question, add a citation…").

## Commits

- `b9712e0` — adds the section, the subsection, the error-list bullet, and the conclusion reword.
- `057e6cb` — removes a claim from the first commit which asserted that writers reach for "obviously" most often at the steps they have checked least carefully. That is an empirical claim about writer behavior with no citation, in a chapter about not making unsupported claims. Replaced with the part the argument needs: working a step out is how you learn whether it holds, and calling it obvious settles the question by assertion instead.
- `9dcdcf5` — merge of `main` (not mine), bringing in the `claude-code-review` workflow fix from #44.
- `530e34c` — review round 1: drops a spaced em-dash used as a connector, extends the "clearly" carve-out to cover "of course", and aligns the phrase in the errors bullet with the one in the section list.
- `08a5a9f` — review round 2: converts the three-term enumeration in the worked example into a bullet list, per CLAUDE.md's rule for lists of three or more items.

## Verification

- `quarto render chapters/citations-evidence.qmd` to HTML and RevealJS: both succeed, the example callout and the display math render, the bullet list nests correctly inside the blockquote, and no cross-references are unresolved.
- `.github/scripts/check-non-standard-chars.py`: passes.
- The log-likelihood in the example was checked term by term against the described decomposition, including the sign on the last term.
- No R code changed, so no lint run was needed.

## Open question

The section sits in *Citations and evidence* because the remedy is prove-or-cite. It would also fit in *Word choice*, beside "Avoid vague and metaphorical language", if you would rather keep word-level tone advice together.